### PR TITLE
build: remove `.ts` file includes

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,10 +9,6 @@
     "src/polyfills.ts"
   ],
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/test.ts",
-    "src/**/*.spec.ts"
+    "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
This fixes warnings such as `WARNING in /home/gitpod/.cache/bazel/_bazel_gitpod/9ee99402aa38cb79ec57f31ff560e386/sandbox/processwrapper-sandbox/1/execroot/angular_cli_demo/src/environments/environment.prod.ts is part of the TypeScript compilation but it's unused.` during compilation.